### PR TITLE
workaround hatch version truncation

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,7 +19,7 @@ actions: &base-actions
   create-archive:
     - hatch run docs:man
     - hatch build -t sdist
-    - bash -c "echo dist/tmt-$PACKIT_PROJECT_VERSION.tar.gz"
+    - bash -c "echo dist/tmt-$PACKIT_PROJECT_VERSION*.tar.gz"
   get-current-version:
     - hatch version
 


### PR DESCRIPTION
If the git hash ends with an `a` (maybe other), hatch version truncates the version. Either that, or there is some other difference in the version handling of that and hatch sdist.

Regardless this should be a safe enough fix to incorporate

---

Pull Request Checklist

* [x] implement the feature